### PR TITLE
how-to-use-pry

### DIFF
--- a/gapic-generator/gapic-generator.gemspec
+++ b/gapic-generator/gapic-generator.gemspec
@@ -47,6 +47,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "minitest-autotest", "~> 1.0"
   spec.add_development_dependency "minitest-focus", "~> 1.0"
+  spec.add_development_dependency "pry", "~> 0.12.2"
+  spec.add_development_dependency "pry-byebug", "~> 3.8.0"
   spec.add_development_dependency "rake", ">= 12.0"
   spec.add_development_dependency "redcarpet", "~> 3.0"
   spec.add_development_dependency "yard", "~> 0.9"

--- a/gapic-generator/lib/gapic/generators/default_generator.rb
+++ b/gapic-generator/lib/gapic/generators/default_generator.rb
@@ -46,6 +46,15 @@ module Gapic
 
         gem = Gapic::Presenters.gem_presenter @api
 
+        STDERR.puts "==============================================="
+        STDERR.puts debugging is supposed to start
+        STDERR.puts "==============================================="
+
+        require 'pry'
+        binding.pry
+        
+        abort
+
         gem.packages.each do |package|
           # Package level files
           files << g("package.erb", "lib/#{package.package_file_path}", package: package)


### PR DESCRIPTION
### Step 1: [add `pry` gem to the `gapic-generator.gemspec` ](https://github.com/viacheslav-rostovtsev/gapic-generator-ruby/blob/96cae8a04b77e9dd82944fdd992cb372cd5ea104/gapic-generator/gapic-generator.gemspec#L50) 
(or to the .gemspec of the gapic-generator-cloud/gapic-generator-ads if you are testing those)  and run bundle install
  - I prefer to also use `pry-byebug`

```
spec.add_development_dependency "pry", "~> 0.12"
spec.add_development_dependency "pry-byebug", "~> 3.8"
```

### Step 2: add 
```
require 'pry'
binding.pry
```
to the desired break point. 
  - One of the best entry break point is right in the [generate/0 method of the default_generator](https://github.com/viacheslav-rostovtsev/gapic-generator-ruby/blob/96cae8a04b77e9dd82944fdd992cb372cd5ea104/gapic-generator/lib/gapic/generators/default_generator.rb#L49-L56)
  - I prefer to also add a STDERR statement with some output to quickly see if `pry` silently fails.
  - Adding an `abort` right after is a good idea if you only have one breakpoint since you don't have to remember to exit pry with a bang (`exit!`) every time.

### Step 3: Run via a test task: `bundle exec test:garbage`!!! 

Gen tasks, e.g. `bundle exec rake gen` will not work! pry will not be able to run (bind to the stdio) if you run your code as a protoc plugin. it will silently fail instead. 

if you need to create a test task for a new service (or a new subset of files), look at the `test:garbage` task in the gapic-generator's Rakefile: https://github.com/viacheslav-rostovtsev/gapic-generator-ruby/blob/96cae8a04b77e9dd82944fdd992cb372cd5ea104/gapic-generator/Rakefile#L34-L37
Its primary function is to call up the [DefaultGeneratorGarbageTest](https://github.com/viacheslav-rostovtsev/gapic-generator-ruby/blob/dev/virost/persist/how-to-use-pry/gapic-generator/test/gapic/generators/default_generator_garbage_test.rb): https://github.com/viacheslav-rostovtsev/gapic-generator-ruby/blob/96cae8a04b77e9dd82944fdd992cb372cd5ea104/gapic-generator/test/gapic/generators/default_generator_garbage_test.rb#L20-L27


